### PR TITLE
Infer callback uri if not provided

### DIFF
--- a/lib/omniauth/strategies/openid_connect.rb
+++ b/lib/omniauth/strategies/openid_connect.rb
@@ -63,7 +63,7 @@ module OmniAuth
       end
 
       def callback_phase
-        client.redirect_uri = client_options.redirect_uri
+        client.redirect_uri = callback_url
         client.authorization_code = authorization_code
         access_token
         super
@@ -84,7 +84,7 @@ module OmniAuth
       end
 
       def authorize_uri
-        client.redirect_uri = client_options.redirect_uri
+        client.redirect_uri = callback_url
         client.authorization_uri(
           response_type: options.response_type,
           scope: options.scope,
@@ -102,6 +102,10 @@ module OmniAuth
 
       def session
         @env.nil? ? {} : super
+      end
+
+      def callback_url
+        client_options.redirect_uri || (full_host + script_name + callback_path)
       end
     end
   end


### PR DESCRIPTION
Like the title says.  Right now if the client options specify redirect_uri: nil, authorization can succeed, however when exchanging the auth code for a token, the remote token endpoint will fail because the redirect uri isn't provided.  This uses the same guess for callback url as in the omniauth-oauth2 gem.
