### PR TITLE
use omniauth failure endpoint on failure (missing code)

### DIFF
--- a/lib/omniauth/openid_connect.rb
+++ b/lib/omniauth/openid_connect.rb
@@ -1,2 +1,3 @@
+require "omniauth/openid_connect/errors"
 require "omniauth/openid_connect/version"
 require "omniauth/strategies/openid_connect"

--- a/lib/omniauth/openid_connect/errors.rb
+++ b/lib/omniauth/openid_connect/errors.rb
@@ -1,0 +1,6 @@
+module OmniAuth
+  module OpenIDConnect
+    class Error < RuntimeError; end
+    class MissingCodeError < Error; end
+  end
+end

--- a/lib/omniauth/strategies/openid_connect.rb
+++ b/lib/omniauth/strategies/openid_connect.rb
@@ -63,6 +63,10 @@ module OmniAuth
       end
 
       def callback_phase
+        if !request.params["code"]
+          return fail!(:missing_code, OmniAuth::OpenIDConnect::MissingCodeError.new(request.params["error"]))
+        end
+
         client.redirect_uri = client_options.redirect_uri
         client.authorization_code = authorization_code
         access_token

--- a/test/lib/omniauth/strategies/openid_connect_test.rb
+++ b/test/lib/omniauth/strategies/openid_connect_test.rb
@@ -57,4 +57,16 @@ class OmniAuth::Strategies::OpenIDConnectTest < StrategyTestCase
 
     assert_equal({ token: access_token.access_token }, strategy.credentials)
   end
+
+  def test_failure_endpoint_redirect
+    OmniAuth.config.stubs(:failure_raise_out_environments).returns([])
+    strategy.stubs(:env).returns({})
+    request.stubs(:params).returns({"error" => "access denied"})
+
+    result = strategy.callback_phase
+
+    assert(result.is_a? Array)
+    assert(result[0] == 302, "Redirect")
+    assert(result[1]["Location"] =~ /\/auth\/failure/)
+  end
 end


### PR DESCRIPTION
When the user denies the permission to access their data the callback will be called without a code and with an error instead.

Currently this will result in an exception when the strategy tries to assign nil for the code.
This patch catches that condition and calls fail! which delegates the request to the OmniAuth failure endpoint which can be used by applications to render a proper error page.
