### PR TITLE
Send raw attributes

### DIFF
--- a/lib/omniauth/strategies/openid_connect.rb
+++ b/lib/omniauth/strategies/openid_connect.rb
@@ -47,7 +47,7 @@ module OmniAuth
       end
 
       extra do
-        { raw_info: user_info.as_json } # UserInfo#as_json actually returns a hash
+        { raw_info: user_info.raw_attributes }
       end
 
       credentials do


### PR DESCRIPTION
I'm not _positive_ why but in testing against a client application `as_json` was only returning:
- name
- given_name
- family_name
- nickname
- email

Switching to `raw_attributes` returned the hash I was expecting from the userinfo end point.
