### PR TITLE
Include gender in info

### DIFF
--- a/lib/omniauth/strategies/openid_connect.rb
+++ b/lib/omniauth/strategies/openid_connect.rb
@@ -40,6 +40,7 @@ module OmniAuth
           nickname: user_info.preferred_username,
           first_name: user_info.given_name,
           last_name: user_info.family_name,
+          gender: user_info.gender,
           image: user_info.picture,
           phone: user_info.phone_number,
           urls: { website: user_info.website }

--- a/test/lib/omniauth/strategies/openid_connect_test.rb
+++ b/test/lib/omniauth/strategies/openid_connect_test.rb
@@ -41,6 +41,7 @@ class OmniAuth::Strategies::OpenIDConnectTest < StrategyTestCase
     assert_equal user_info.preferred_username, info[:nickname]
     assert_equal user_info.given_name, info[:first_name]
     assert_equal user_info.family_name, info[:last_name]
+    assert_equal user_info.gender, info[:gender]
     assert_equal user_info.picture, info[:image]
     assert_equal user_info.phone_number, info[:phone]
     assert_equal({ website: user_info.website }, info[:urls])

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -37,6 +37,7 @@ class StrategyTestCase < MiniTest::Test
       preferred_username: Faker::Internet.user_name,
       given_name: Faker::Name.first_name,
       family_name: Faker::Name.last_name,
+      gender: 'female',
       picture: Faker::Internet.url + ".png",
       phone_number: Faker::PhoneNumber.phone_number,
       website: Faker::Internet.url,


### PR DESCRIPTION
In some versions of Rails not having gender will actually case the `openid_connect` gem to through a validation error.

See https://github.com/nov/openid_connect/blob/5a69adf4e774e0d683bbff90d4867dbe20a170c8/lib/openid_connect/response_object/user_info.rb#L29-L36
