### PR TITLE
Fix builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,6 @@
 .bundle
 .config
 .yardoc
-Gemfile.lock
 InstalledFiles
 _yardoc
 coverage

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,159 @@
+PATH
+  remote: .
+  specs:
+    omniauth-openid-connect (0.1.0)
+      activesupport (~> 4.1.6)
+      addressable (~> 2.3)
+      omniauth (~> 1.1)
+      openid_connect (= 0.7.3)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    activemodel (4.1.6)
+      activesupport (= 4.1.6)
+      builder (~> 3.1)
+    activesupport (4.1.6)
+      i18n (~> 0.6, >= 0.6.9)
+      json (~> 1.7, >= 1.7.7)
+      minitest (~> 5.1)
+      thread_safe (~> 0.1)
+      tzinfo (~> 1.1)
+    addressable (2.3.6)
+    attr_required (1.0.0)
+    bindata (2.1.0)
+    builder (3.2.2)
+    celluloid (0.16.0)
+      timers (~> 4.0.0)
+    coderay (1.1.0)
+    coveralls (0.7.1)
+      multi_json (~> 1.3)
+      rest-client
+      simplecov (>= 0.7)
+      term-ansicolor
+      thor
+    docile (1.1.5)
+    faker (1.4.3)
+      i18n (~> 0.5)
+    ffi (1.9.3)
+    formatador (0.2.5)
+    guard (2.6.1)
+      formatador (>= 0.2.4)
+      listen (~> 2.7)
+      lumberjack (~> 1.0)
+      pry (>= 0.9.12)
+      thor (>= 0.18.1)
+    guard-bundler (2.0.0)
+      bundler (~> 1.0)
+      guard (~> 2.2)
+    guard-minitest (2.3.2)
+      guard (~> 2.0)
+      minitest (>= 3.0)
+    hashie (3.3.1)
+    hitimes (1.2.2)
+    httpclient (2.4.0)
+    i18n (0.6.11)
+    json (1.8.1)
+    json-jwt (0.7.0)
+      activesupport
+      bindata
+      multi_json (>= 1.3)
+      securecompare
+      url_safe_base64
+    listen (2.7.9)
+      celluloid (>= 0.15.2)
+      rb-fsevent (>= 0.9.3)
+      rb-inotify (>= 0.9)
+    lumberjack (1.0.9)
+    mail (2.6.1)
+      mime-types (>= 1.16, < 3)
+    metaclass (0.0.4)
+    method_source (0.8.2)
+    mime-types (2.3)
+    minitest (5.4.1)
+    mocha (1.1.0)
+      metaclass (~> 0.0.1)
+    multi_json (1.10.1)
+    netrc (0.7.7)
+    omniauth (1.2.2)
+      hashie (>= 1.2, < 4)
+      rack (~> 1.0)
+    openid_connect (0.7.3)
+      activemodel
+      attr_required (>= 0.0.5)
+      json (>= 1.4.3)
+      json-jwt (>= 0.5.5)
+      rack-oauth2 (>= 1.0.0)
+      swd (>= 0.1.2)
+      tzinfo
+      validate_email
+      validate_url
+      webfinger (>= 0.0.2)
+    pry (0.10.1)
+      coderay (~> 1.1.0)
+      method_source (~> 0.8.1)
+      slop (~> 3.4)
+    rack (1.5.2)
+    rack-oauth2 (1.0.8)
+      activesupport (>= 2.3)
+      attr_required (>= 0.0.5)
+      httpclient (>= 2.2.0.2)
+      multi_json (>= 1.3.6)
+      rack (>= 1.1)
+    rake (10.3.2)
+    rb-fsevent (0.9.4)
+    rb-inotify (0.9.5)
+      ffi (>= 0.5.0)
+    rest-client (1.7.2)
+      mime-types (>= 1.16, < 3.0)
+      netrc (~> 0.7)
+    securecompare (1.0.0)
+    simplecov (0.9.0)
+      docile (~> 1.1.0)
+      multi_json
+      simplecov-html (~> 0.8.0)
+    simplecov-html (0.8.0)
+    slop (3.6.0)
+    swd (0.2.1)
+      activesupport (>= 3)
+      attr_required (>= 0.0.5)
+      httpclient (>= 2.2.1)
+      i18n
+      json (>= 1.4.3)
+    term-ansicolor (1.3.0)
+      tins (~> 1.0)
+    thor (0.19.1)
+    thread_safe (0.3.4)
+    timers (4.0.1)
+      hitimes
+    tins (1.3.2)
+    tzinfo (1.2.2)
+      thread_safe (~> 0.1)
+    url_safe_base64 (0.2.2)
+    validate_email (0.1.6)
+      activemodel (>= 3.0)
+      mail (>= 2.2.5)
+    validate_url (0.2.2)
+      activemodel (>= 3.0.0)
+      addressable
+    webfinger (1.0.0)
+      activesupport
+      httpclient (>= 2.2.0.2)
+      multi_json
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  bundler (~> 1.5)
+  coveralls
+  faker
+  guard
+  guard-bundler
+  guard-minitest
+  minitest
+  mocha
+  omniauth-openid-connect!
+  pry
+  rake
+  simplecov

--- a/omniauth-openid-connect.gemspec
+++ b/omniauth-openid-connect.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'activesupport'
+  spec.add_dependency 'activesupport', '~> 4.1.6'
   spec.add_dependency 'omniauth', '~> 1.1'
   spec.add_dependency 'openid_connect', '= 0.7.3'
   spec.add_dependency 'addressable', '~> 2.3'


### PR DESCRIPTION
Not sure this is the real fix but locking activesupport to the same version the `openid-connect` gem is using...
