### PR TITLE
Set default name for strategy, fix typo

### DIFF
--- a/lib/omniauth/strategies/openid_connect.rb
+++ b/lib/omniauth/strategies/openid_connect.rb
@@ -77,10 +77,6 @@ module OmniAuth
       end
 
       def config
-        uri = URI.parse(options.issuer)
-        if uri.scheme == 'http'
-          SWD.url_builder = URI::HTTP
-        end
         @config ||= ::OpenIDConnect::Discovery::Provider::Config.discover!(options.issuer)
       end
 

--- a/lib/omniauth/strategies/openid_connect.rb
+++ b/lib/omniauth/strategies/openid_connect.rb
@@ -22,6 +22,7 @@ module OmniAuth
         userinfo_endpoint: "/userinfo",
         jwks_uri: '/jwk'
       }
+      option :name, :openid_connect
       option :issuer
       option :discovery, false
       option :client_signing_alg
@@ -126,7 +127,7 @@ module OmniAuth
       end
 
       def public_key
-        if options.discover
+        if options.discovery
           config.public_keys.first
         else
           key_or_secret

--- a/lib/omniauth/strategies/openid_connect.rb
+++ b/lib/omniauth/strategies/openid_connect.rb
@@ -77,6 +77,10 @@ module OmniAuth
       end
 
       def config
+        uri = URI.parse(options.issuer)
+        if uri.scheme == 'http'
+          SWD.url_builder = URI::HTTP
+        end
         @config ||= ::OpenIDConnect::Discovery::Provider::Config.discover!(options.issuer)
       end
 


### PR DESCRIPTION
While trying to use this gem with the setup_phase (https://github.com/intridea/omniauth/wiki/Setup-Phase) of omniauth for
dynamically assigning strategy options, I noticed that the name field
was defaulting to OpenIDConnect instead of openid_connect, which is
what the default route would be for omniauth, since the name isn't set
in the options until after it is needed in this case. Providing a
default name if one isn't set fixes that problem.

Regarding the typo. options.dicovery needed to be added, otherwise
public_key was being set to nil when using discovery with alternative
server signing algorithms.