### PR TITLE
fixed typo

### DIFF
--- a/lib/omniauth/strategies/openid_connect.rb
+++ b/lib/omniauth/strategies/openid_connect.rb
@@ -126,7 +126,7 @@ module OmniAuth
       end
 
       def public_key
-        if options.discover
+        if options.discovery
           config.public_keys.first
         else
           key_or_secret


### PR DESCRIPTION
Without having tested it properly I think this would have to be `discovery` as opposed to just `discover`.