### PR TITLE
Allow passing custom authorization uri option

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ Configuration details:
   If provider does not have Webfinger endpoint, You can specify "Issuer" to option.  
   e.g. `issuer: "myprovider.com"`  
   It means to get configuration from "https://myprovider.com/.well-known/openid-configuration".
+  * `authorization_opts` if you want to pass custom authorization options
+  e.g. `{:'openid.realm' => "..."}`
 
 For the full low down on OpenID Connect, please check out
 [the spec](http://openid.net/specs/openid-connect-core-1_0.html).

--- a/lib/omniauth/strategies/openid_connect.rb
+++ b/lib/omniauth/strategies/openid_connect.rb
@@ -40,6 +40,7 @@ module OmniAuth
       option :acr_values
       option :send_nonce, true
       option :client_auth_method
+      option :authorization_opts, {}
 
       uid { user_info.sub }
 
@@ -116,12 +117,13 @@ module OmniAuth
 
       def authorize_uri
         client.redirect_uri = client_options.redirect_uri
-        opts = {
+        # to_hash as authorization_opts is a Hashi::mash causing dup query keys
+        opts = options.authorization_opts.to_hash.merge({
             response_type: options.response_type,
             scope: options.scope,
             state: new_state,
             nonce: (new_nonce if options.send_nonce),
-        }
+        })
         client.authorization_uri(opts.reject{|k,v| v.nil?})
       end
 

--- a/test/lib/omniauth/strategies/openid_connect_test.rb
+++ b/test/lib/omniauth/strategies/openid_connect_test.rb
@@ -323,4 +323,10 @@ class OmniAuth::Strategies::OpenIDConnectTest < StrategyTestCase
     strategy.options.client_signing_alg = :HS256
     assert_equal strategy.options.client_options.secret, strategy.public_key
   end
+
+  def test_option_authorization_opts
+    strategy.options.client_options[:host] = "example.com"
+    strategy.options.authorization_opts = {:'openid.realm' => 'realm'}
+    assert(strategy.authorize_uri =~ /^https:\/\/example\.com\/authorize\?client_id=1234&nonce=[\w\d]{32}&openid\.realm=realm&response_type=code&scope=openid&state=[\w\d]{32}$/, "URI must contain openid.realm")
+  end
 end


### PR DESCRIPTION
Useful when migrating from OpenID to OpenID connect.
