### PR TITLE
Use config.jwks to support multiple keys

### DIFF
--- a/lib/omniauth/strategies/openid_connect.rb
+++ b/lib/omniauth/strategies/openid_connect.rb
@@ -127,7 +127,7 @@ module OmniAuth
 
       def public_key
         if options.discovery
-          config.public_keys.first
+          config.jwks
         else
           key_or_secret
         end

--- a/omniauth-openid-connect.gemspec
+++ b/omniauth-openid-connect.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency 'omniauth', '~> 1.1'
-  spec.add_dependency 'openid_connect', '= 0.7.3'
+  spec.add_dependency 'openid_connect', '= 0.9.0'
   spec.add_dependency 'addressable', '~> 2.3'
   spec.add_development_dependency "bundler", "~> 1.5"
   spec.add_development_dependency "minitest"

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -30,7 +30,7 @@ class StrategyTestCase < MiniTest::Test
   end
 
   def user_info
-    @user_info ||= OpenIDConnect::ResponseObject::UserInfo::OpenID.new(
+    @user_info ||= OpenIDConnect::ResponseObject::UserInfo.new(
       sub: SecureRandom.hex(16),
       name: Faker::Name.name,
       email: Faker::Internet.email,


### PR DESCRIPTION
Requires openid_connect 0.9.0

Also update tests to work with new openid_connect version.
OpenID class refactored in 5a69adf4e774e0d683bbff90d4867dbe20a170c8