### PR TITLE
Add send_scope_to_token_endpoint option

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+before_install:
+  - gem update bundler
 rvm:
   - 1.9.3
   - 2.0.0

--- a/lib/omniauth/strategies/openid_connect.rb
+++ b/lib/omniauth/strategies/openid_connect.rb
@@ -40,6 +40,7 @@ module OmniAuth
       option :login_hint
       option :acr_values
       option :send_nonce, true
+      option :send_scope_to_token_endpoint, true
       option :client_auth_method
 
       uid { user_info.sub }
@@ -156,7 +157,7 @@ module OmniAuth
       def access_token
         @access_token ||= lambda {
           _access_token = client.access_token!(
-          scope: options.scope,
+          scope: (options.scope if options.send_scope_to_token_endpoint),
           client_auth_method: options.client_auth_method
           )
           _id_token = decode_id_token _access_token.id_token


### PR DESCRIPTION
Some of OpenID Connect Provider doesn't accept the scope parameter in
token endpoint.

For example, OpenAM returns the invalid_request error like following, if scope
parameter in token request.

> Scope parameter is not supported on an authorization code access_token
> exchange request. Scope parameter should be supplied to the authorize request.

cf.

> Also, the scope parameter is not valid on a token request with an authorization code grant.
http://sources.forgerock.org/cru/CR-5286

and

https://bugster.forgerock.org/jira/browse/OPENAM-4830