### PR TITLE
Add support for (optional) claims request parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,26 @@ Configuration details:
   If provider does not have Webfinger endpoint, You can specify "Issuer" to option.  
   e.g. `issuer: "https://myprovider.com"`  
   It means to get configuration from "https://myprovider.com/.well-known/openid-configuration".
+  * Supports requesting Claims using the `claims` Request Parameter
+    (http://openid.net/specs/openid-connect-core-1_0.html#ClaimsParameter).
+    Example configuration:
+    ```ruby
+    config.omniauth :openid_connect, {
+      name: :my_provider,
+      claims: {
+        id_token: {
+          acr: {
+            essential: true,
+            values: ['urn:mace:incommon:iap:silver', 'urn:mace:incommon:iap:bronze']
+          }
+        }
+        userinfo: {
+          email_verified:         { essential: true },
+          email:                  { essential: true }
+        }
+      },
+      ...
+    ```
 
 For the full low down on OpenID Connect, please check out
 [the spec](http://openid.net/specs/openid-connect-core-1_0.html).

--- a/lib/omniauth/strategies/openid_connect.rb
+++ b/lib/omniauth/strategies/openid_connect.rb
@@ -42,6 +42,7 @@ module OmniAuth
       option :send_nonce, true
       option :send_scope_to_token_endpoint, true
       option :client_auth_method
+      option :claims, nil
 
       uid { user_info.sub }
 
@@ -124,6 +125,7 @@ module OmniAuth
             state: new_state,
             nonce: (new_nonce if options.send_nonce),
             hd: options.hd,
+            claims: (options.claims.to_json unless options.claims.nil?)
         }
         client.authorization_uri(opts.reject{|k,v| v.nil?})
       end

--- a/test/lib/omniauth/strategies/openid_connect_test.rb
+++ b/test/lib/omniauth/strategies/openid_connect_test.rb
@@ -242,6 +242,18 @@ class OmniAuth::Strategies::OpenIDConnectTest < StrategyTestCase
     assert(!(strategy.authorize_uri =~ /nonce=/), "URI must not contain nonce")
   end
 
+  def test_option_claims
+    strategy.options.client_options[:host] = 'foobar.com'
+
+    assert(!(strategy.authorize_uri =~ /claims=/), 'URI must not contain claims')
+
+    strategy.options.claims = {}
+    assert(strategy.authorize_uri =~ /claims=/, 'URI must contain claims')
+
+    strategy.options.claims = { looks_like_json: true }
+    assert(strategy.authorize_uri =~ /claims=%7B%22looks_like_json%22%3Atrue%7D/, 'claims should be formatted as JSON')
+  end
+
   def test_failure_endpoint_redirect
     OmniAuth.config.stubs(:failure_raise_out_environments).returns([])
     strategy.stubs(:env).returns({})


### PR DESCRIPTION
Quote from the OpenID Connect specification:

> OpenID Connect defines the following Authorization Request parameter to enable requesting individual Claims.
> 
> The claims Authentication Request parameter requests that specific Claims be returned from the UserInfo Endpoint and/or in the ID Token. It is represented as a JSON object containing lists of Claims being requested from these locations. Properties of the Claims being requested MAY also be specified.
> 
> http://openid.net/specs/openid-connect-core-1_0.html#ClaimsParameter
