### PR TITLE
Added support for (optional) acr_values request parameter

### DIFF
--- a/lib/omniauth/strategies/openid_connect.rb
+++ b/lib/omniauth/strategies/openid_connect.rb
@@ -124,6 +124,7 @@ module OmniAuth
             state: new_state,
             nonce: (new_nonce if options.send_nonce),
             hd: options.hd,
+            acr_values: options.acr_values
         }
         client.authorization_uri(opts.reject{|k,v| v.nil?})
       end

--- a/test/lib/omniauth/strategies/openid_connect_test.rb
+++ b/test/lib/omniauth/strategies/openid_connect_test.rb
@@ -242,6 +242,16 @@ class OmniAuth::Strategies::OpenIDConnectTest < StrategyTestCase
     assert(!(strategy.authorize_uri =~ /nonce=/), "URI must not contain nonce")
   end
 
+  def test_option_acr_values
+    strategy.options.client_options[:host] = 'foobar.com'
+
+    assert(!(strategy.authorize_uri =~ /acr_values=/), 'URI must not contain acr_values')
+
+    strategy.options.acr_values = 'urn:mace:incommon:iap:silver'
+    assert(strategy.authorize_uri =~ /acr_values=/, 'URI must contain acr_values')
+  end
+
+
   def test_failure_endpoint_redirect
     OmniAuth.config.stubs(:failure_raise_out_environments).returns([])
     strategy.stubs(:env).returns({})


### PR DESCRIPTION
The `acr_values` can be specified as `option` parameter, but are currently not included in the Authentication Request.

OpenID Connect (http://openid.net/specs/openid-connect-core-1_0.html#AuthRequest) specifies this as an optional parameter.
