### PR TITLE
Convert client_signing_alg to symbol in key_or_secret.

### DIFF
--- a/lib/omniauth/strategies/openid_connect.rb
+++ b/lib/omniauth/strategies/openid_connect.rb
@@ -201,7 +201,7 @@ module OmniAuth
       end
 
       def key_or_secret
-        case options.client_signing_alg
+        case options.client_signing_alg.to_sym
           when :HS256, :HS384, :HS512
             return client_options.secret
           when :RS256, :RS384, :RS512


### PR DESCRIPTION
Fixes #57 

The options.client_signing_alg is provided as string by Gitlab when using omnibus for configuration, but is checked against symbol values.

For the cases where the `client_signing_alg` value is already provided as symbol, the change will have no side effect and the no code changes are required.
