### PR TITLE
Make uid label configurable

### DIFF
--- a/lib/omniauth/strategies/openid_connect.rb
+++ b/lib/omniauth/strategies/openid_connect.rb
@@ -42,8 +42,11 @@ module OmniAuth
       option :send_nonce, true
       option :send_scope_to_token_endpoint, true
       option :client_auth_method
+      option :uid_field, 'sub'
 
-      uid { user_info.sub }
+      uid do
+          user_info.send(options.uid_field.to_s)
+      end
 
       info do
         {


### PR DESCRIPTION
The uid is always using the _sub_ value from the _userinfo_, which in some applications is not the expected value.

To avoid such limitations, the uid label is now configurable by configuring the omniauth _uid_label_ option to a different label that apears in the userinfo details. 

The default value for _uid_label_ is set to _sub_ to ensure the backward compatibility is not broken.
