### PR TITLE
[WIP] Support Dynamic Client Registration

### DIFF
--- a/lib/omniauth/strategies/openid_connect.rb
+++ b/lib/omniauth/strategies/openid_connect.rb
@@ -81,6 +81,8 @@ module OmniAuth
               %i(authorization_endpoint token_endpoint userinfo_endpoint).each do |key|
                 client.send :"#{key}=", client_options[key]
               end
+              client_options.identifier = client.identifier
+              client_options.secret = client.secret
             end
           else
              ::OpenIDConnect::Client.new(client_options)

--- a/lib/omniauth/strategies/openid_connect.rb
+++ b/lib/omniauth/strategies/openid_connect.rb
@@ -16,7 +16,7 @@ module OmniAuth
         redirect_uri: nil,
         scheme: "https",
         host: nil,
-        port: nil,
+        port: 443,
         authorization_endpoint: "/authorize",
         token_endpoint: "/token",
         userinfo_endpoint: "/userinfo",
@@ -94,10 +94,6 @@ module OmniAuth
       end
 
       def request_phase
-        if client_options.scheme == "http"
-          WebFinger.url_builder = URI::HTTP
-          SWD.url_builder = URI::HTTP
-        end
         options.issuer = issuer if options.issuer.blank?
         discover! if options.discovery
         redirect authorize_uri


### PR DESCRIPTION
Adds support for Dynamic Client Registration (see
https://openid.net/specs/openid-connect-registration-1_0.html).

Dynamic Client Registration is initiated when no identifier was supplied among
the client_options.

Also, this includes changes for the better handling of "http" schema (useful in testing).

fixes #46 

TODO:
- [ ] Add some tests
