### PR TITLE
Verify UserInfo Response

### DIFF
--- a/lib/omniauth/strategies/openid_connect.rb
+++ b/lib/omniauth/strategies/openid_connect.rb
@@ -43,7 +43,7 @@ module OmniAuth
       option :send_scope_to_token_endpoint, true
       option :client_auth_method
 
-      uid { user_info.sub }
+      uid { id_token.sub }
 
       info do
         {

--- a/lib/omniauth/strategies/openid_connect.rb
+++ b/lib/omniauth/strategies/openid_connect.rb
@@ -161,24 +161,28 @@ module OmniAuth
         end
       end
 
-      def access_token
-        @access_token ||= begin
+      def access_and_id_tokens
+        @tokens ||= begin
           _access_token = client.access_token!(
           scope: (options.scope if options.send_scope_to_token_endpoint),
           client_auth_method: options.client_auth_method
           )
-          @id_token = decode_id_token _access_token.id_token
-          @id_token.verify!(
+          _id_token = decode_id_token _access_token.id_token
+          _id_token.verify!(
               issuer: options.issuer,
               client_id: client_options.identifier,
               nonce: stored_nonce
           )
-          _access_token
+          [_access_token, _id_token]
         end
       end
 
+      def access_token
+        @access_token ||= access_and_id_tokens[0]
+      end
+
       def id_token
-        @id_token
+        @id_token ||= access_and_id_tokens[1]
       end
 
       def decode_id_token(id_token)

--- a/lib/omniauth/strategies/openid_connect.rb
+++ b/lib/omniauth/strategies/openid_connect.rb
@@ -162,7 +162,7 @@ module OmniAuth
       end
 
       def access_token
-        @access_token ||= lambda {
+        @access_token ||= begin
           _access_token = client.access_token!(
           scope: (options.scope if options.send_scope_to_token_endpoint),
           client_auth_method: options.client_auth_method
@@ -174,7 +174,7 @@ module OmniAuth
               nonce: stored_nonce
           )
           _access_token
-        }.call()
+        end
       end
 
       def id_token


### PR DESCRIPTION
According to the OpenID Connect spec, for security reasons, we must verify that the subject of the UserInfo response matches the subject of the ID Token. If they do not match, then the client _MUST_ discard the UserInfo response.

This pull request addresses that, as well as changes the `uid` to read from the ID Token and not the UserInfo response.

Fixes #62 
