### PR TITLE
Add ux parameter support

### DIFF
--- a/lib/omniauth/strategies/openid_connect.rb
+++ b/lib/omniauth/strategies/openid_connect.rb
@@ -125,6 +125,7 @@ module OmniAuth
             nonce: (new_nonce if options.send_nonce),
             hd: options.hd,
             prompt: options.prompt,
+            id_token_hint: options.id_token_hint,
         }
         client.authorization_uri(opts.reject{|k,v| v.nil?})
       end

--- a/lib/omniauth/strategies/openid_connect.rb
+++ b/lib/omniauth/strategies/openid_connect.rb
@@ -124,6 +124,7 @@ module OmniAuth
             state: new_state,
             nonce: (new_nonce if options.send_nonce),
             hd: options.hd,
+            prompt: options.prompt,
         }
         client.authorization_uri(opts.reject{|k,v| v.nil?})
       end

--- a/lib/omniauth/strategies/openid_connect.rb
+++ b/lib/omniauth/strategies/openid_connect.rb
@@ -42,6 +42,7 @@ module OmniAuth
       option :send_nonce, true
       option :send_scope_to_token_endpoint, true
       option :client_auth_method
+      option :ux
 
       uid { user_info.sub }
 
@@ -126,6 +127,7 @@ module OmniAuth
             hd: options.hd,
             prompt: options.prompt,
             id_token_hint: options.id_token_hint,
+            ux: options.ux,
         }
         client.authorization_uri(opts.reject{|k,v| v.nil?})
       end

--- a/test/lib/omniauth/strategies/openid_connect_test.rb
+++ b/test/lib/omniauth/strategies/openid_connect_test.rb
@@ -249,6 +249,13 @@ class OmniAuth::Strategies::OpenIDConnectTest < StrategyTestCase
     assert(strategy.authorize_uri =~ /prompt=login/, "URI must contain prompt")
   end
 
+  def test_option_prompt
+    strategy.options.client_options[:host] = "foobar.com"
+
+    strategy.options.id_token_hint = "2983049820398423"
+    assert(strategy.authorize_uri =~ /id_token_hint=2983049820398423/, "URI must contain id_token_hint")
+  end
+
   def test_failure_endpoint_redirect
     OmniAuth.config.stubs(:failure_raise_out_environments).returns([])
     strategy.stubs(:env).returns({})

--- a/test/lib/omniauth/strategies/openid_connect_test.rb
+++ b/test/lib/omniauth/strategies/openid_connect_test.rb
@@ -242,6 +242,13 @@ class OmniAuth::Strategies::OpenIDConnectTest < StrategyTestCase
     assert(!(strategy.authorize_uri =~ /nonce=/), "URI must not contain nonce")
   end
 
+  def test_option_prompt
+    strategy.options.client_options[:host] = "foobar.com"
+
+    strategy.options.prompt = "login"
+    assert(strategy.authorize_uri =~ /prompt=login/, "URI must contain prompt")
+  end
+
   def test_failure_endpoint_redirect
     OmniAuth.config.stubs(:failure_raise_out_environments).returns([])
     strategy.stubs(:env).returns({})


### PR DESCRIPTION
This adds support for passing the `ux` parameter to ID.  I'll initially use this to send `ux=signup` to ask for signup to be shown rather than login in rare use cases.