### PR TITLE
loosen gem requirements, bump version

### DIFF
--- a/lib/omniauth/openid_connect/version.rb
+++ b/lib/omniauth/openid_connect/version.rb
@@ -1,5 +1,5 @@
 module OmniAuth
   module OpenIDConnect
-    VERSION = "0.2.2"
+    VERSION = "0.2.4"
   end
 end

--- a/omniauth-openid-connect.gemspec
+++ b/omniauth-openid-connect.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency 'omniauth', '~> 1.1'
-  spec.add_dependency 'openid_connect', '~> 0.9.2'
+  spec.add_dependency 'openid_connect', '>= 0.9.2'
   spec.add_dependency 'addressable', '~> 2.3'
   spec.add_development_dependency "bundler", "~> 1.5"
   spec.add_development_dependency "minitest"


### PR DESCRIPTION
The locked version of the openid_connect gem is now falling foul of deprecated methods, which were replaced in this commit:

https://github.com/nov/openid_connect/commit/9b205097b238c1cbe214e72306e262bd70640adf

This PR just unlocks the gem version so that bundle updates on projects requiring omniauth-openid-connect can use later versions of the openid_connect gem if necessary.

(I've specified it as 0.9.2 as a minimum, but no upper bound. You might have opinions on that  - I think the current 1.1.2 version is still good for use with omniauth-openid-connect, but if you want a less open version specification it should at least allow 0.11.0)